### PR TITLE
fix: disable provider cache

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,9 +43,6 @@ RUN set -euo pipefail; \
 
 USER atlantis
 
-# Enable provider plugin cache
-# See: https://www.terraform.io/cli/config/config-file#provider-plugin-cache
-ENV TF_PLUGIN_CACHE_DIR="/home/atlantis/.terraform.d/plugin-cache"
 RUN set -euo pipefail; \
     helm plugin install https://github.com/jkroepke/helm-secrets --version v${HELM_SECRETS_VERSION}; \
     mkdir -p "${TF_PLUGIN_CACHE_DIR}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,8 +44,7 @@ RUN set -euo pipefail; \
 USER atlantis
 
 RUN set -euo pipefail; \
-    helm plugin install https://github.com/jkroepke/helm-secrets --version v${HELM_SECRETS_VERSION}; \
-    mkdir -p "${TF_PLUGIN_CACHE_DIR}"
+    helm plugin install https://github.com/jkroepke/helm-secrets --version v${HELM_SECRETS_VERSION}
 
 USER root
 


### PR DESCRIPTION
When enabled, Atlantis fails with the following error:

the cached package for registry.terraform.io/hashicorp/aws 4.1.0 (in .terraform/providers) does not match any of the checksums recorded in the dependency lock file